### PR TITLE
improved endscreentweaks compat + ios support

### DIFF
--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -18,9 +18,9 @@ jobs:
         - name: macOS
           os: macos-latest
 
-        #- name: iOS
-        #  os: macos-latest
-        #  target: iOS
+        - name: iOS
+          os: macos-latest
+          target: iOS
 
         - name: Android32
           os: ubuntu-latest

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,8 +28,9 @@ class $modify(MyEndLevelLayer, EndLevelLayer) {
 
 		CCLabelBMFont* counter = CCLabelBMFont::create(fmt::format("Key: {}/500", calculateOrbsToNextKey()).c_str(), "goldFont.fnt");
 		counter->setScale(0.8f);
-		counter->setAnchorPoint({1.f, 0.f});
-		counter->setPosition({0, 0});
+		// counter->setAnchorPoint({.5f, .5f}); // unneeded, allows for consistent anchor point and x-position compared to vanilla gold labels
+		// counter->setPosition({0, 0}); // unneeded, allows for consistent anchor point and x-position compared to vanilla gold labels
+		counter->setID("orb-counter"_spr);
 
 		CCNode* labelContainer = CCNode::create();
 		labelContainer->setPosition({winSize.width/2, winSize.height/2 + 8});
@@ -46,7 +47,10 @@ class $modify(MyEndLevelLayer, EndLevelLayer) {
 
 		for (CCNode* child : CCArrayExt<CCNode*>(m_mainLayer->getChildren())) {
 			if (CCLabelBMFont* label = typeinfo_cast<CCLabelBMFont*>(child)) {
-				if (label->getPositionX() == winSize.width/2) {
+				// skip non-goldfont labels, especially end-text
+				// otherwise it causes weird results like https://discord.com/channels/911701438269386882/911702535373475870/1402125928141684778
+				if (label->getID() == "end-text") continue; // arguably i could move this to be outside the typeinfocast but it's here for readability
+				if (label->getPositionX() == winSize.width/2 && std::string(label->getFntFile()) == "goldFont.fnt") {
 					nodesToMove.push_back(label);
 				}
 			}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,8 @@ class $modify(MyCurrencyRewardLayer, CurrencyRewardLayer) {
 				counter->setScale(0.3f);
 				counter->setAnchorPoint({1.f, 1.f});
 				counter->setPosition({0, -m_orbsLabel->getScaledContentHeight() + 1});
-				
+				counter->setID("orb-counter"_spr);
+
 				m_mainNode->addChild(counter);
 			}
 		}
@@ -111,6 +112,7 @@ class $modify(MyPauseLayer, PauseLayer) {
 			counter->setAnchorPoint({1.f, 0.5f});
 			counter->setPosition({normalModeLabel->getPositionX() + 170, normalModeLabel->getPositionY()});
 			counter->setColor({45, 255, 255});
+			counter->setID("orb-counter"_spr);
 
 			addChild(counter);
 		}


### PR DESCRIPTION
currently this code puts `end-text` inside of the label container which can cause visual snags like this one:
<img src="https://github.com/user-attachments/assets/eb8ef4e3-bede-45b6-9565-7e5ade1852a8" />
so i decided to check for fntfile of each label before adding it to the container

also, since endscreentweaks allows you to change the font of the `end-text` node i went ahead and added a check specifically to skip the `end-text` node in the forloop. arguably it deserves to be done before performing a typeinfo cast, but i left it inside the typeinfocast to make it clear what i was doing

also:
- gave your "Key: {}" label a node ID throughout all non-GJGarageLayer hooks
- removed the anchorpoint and positioning calls on the "Key: {}" label in EndLevelLayer so it has consistent xPos and anchor points with other vanilla nodes
- i found the missing binding for iOS so i went ahead and re-enabled iOS compiling in the workflow file